### PR TITLE
Enable keyAgreement for keyUsage field for SECC certificate

### DIFF
--- a/RISE-V2G-Certificates/configs/seccCert.cnf
+++ b/RISE-V2G-Certificates/configs/seccCert.cnf
@@ -10,6 +10,6 @@ domainComponent			= CPO
 
 [ext]
 basicConstraints		= critical,CA:false
-keyUsage				= critical,digitalSignature
+keyUsage				= critical,digitalSignature,keyAgreement
 subjectKeyIdentifier	= hash
 


### PR DESCRIPTION
According to ISO 15118-2 the SECC certificate must have the keyAgreement
bit set in keyUsage. This makes sense since the certificate is used for
Diffie Hellmann key exchange in the TLS connection.

Signed-off-by: Michael Heimpold <michael.heimpold@i2se.com>