### PR TITLE
Make sure moSubCA2.pkcs8.der is added to SECC archives

### DIFF
--- a/RISE-V2G-SECC/src/assembly/bin.xml
+++ b/RISE-V2G-SECC/src/assembly/bin.xml
@@ -25,6 +25,7 @@
 			<includes>
 				<include>*.p12</include>
 				<include>*.jks</include>
+				<include>*.pkcs8.der</include>
 			</includes>
 		</fileSet>
 		<fileSet>


### PR DESCRIPTION
Make sure MO Sub-CA 2 PKCS#8 file is added to package, because it's required by SECC dummy backend