### PR TITLE
Change module paths to lowercase

### DIFF
--- a/RISE-V2G-EVCC/pom.xml
+++ b/RISE-V2G-EVCC/pom.xml
@@ -5,7 +5,7 @@
 		<groupId>com.v2gclarity.risev2g</groupId>
 		<artifactId>rise-v2g-parent</artifactId>
 		<version>1.1.4-SNAPSHOT</version>
-		<relativePath>../RISE-V2G-PARENT</relativePath>
+		<relativePath>../rise-v2g-parent</relativePath>
 	</parent>
 	
 	<modelVersion>4.0.0</modelVersion>

--- a/RISE-V2G-PARENT/pom.xml
+++ b/RISE-V2G-PARENT/pom.xml
@@ -11,9 +11,9 @@
 	<packaging>pom</packaging>
 	
 	<modules>
-		<module>../RISE-V2G-EVCC</module>
-		<module>../RISE-V2G-SECC</module>
-		<module>../RISE-V2G-Shared</module>
+		<module>../rise-v2g-evcc</module>
+		<module>../rise-v2g-secc</module>
+		<module>../rise-v2g-shared</module>
 	</modules>
 	
 	<url>https://www.v2g-clarity.com/en/risev2g/</url>

--- a/RISE-V2G-SECC/pom.xml
+++ b/RISE-V2G-SECC/pom.xml
@@ -5,7 +5,7 @@
 		<groupId>com.v2gclarity.risev2g</groupId>
 		<artifactId>rise-v2g-parent</artifactId>
 		<version>1.1.4-SNAPSHOT</version>
-		<relativePath>../RISE-V2G-PARENT</relativePath>
+		<relativePath>../rise-v2g-parent</relativePath>
 	</parent>
 	
 	<modelVersion>4.0.0</modelVersion>

--- a/RISE-V2G-Shared/pom.xml
+++ b/RISE-V2G-Shared/pom.xml
@@ -5,7 +5,7 @@
 		<groupId>com.v2gclarity.risev2g</groupId>
 		<artifactId>rise-v2g-parent</artifactId>
 		<version>1.1.4-SNAPSHOT</version>
-		<relativePath>../RISE-V2G-PARENT</relativePath>
+		<relativePath>../rise-v2g-parent</relativePath>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Wanted to suggest this, because I ran into trouble building the project on Unix systems. The files are actually lowercase, and when I tried to build them on Unix-like systems, the relative paths are wrong. This is probably different on DOS systems, where the is no difference between upper and lowercase names.