### PR TITLE
make signature of encryptContractCertPrivateKey more specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ RISE-V2G-SECC/cpsCertChain.p12
 RISE-V2G-SECC/moCertChain.p12
 /.metadata/
 /.recommenders/
+.idea
+*.iml

--- a/RISE-V2G-Certificates/generateCertificates.sh
+++ b/RISE-V2G-Certificates/generateCertificates.sh
@@ -247,7 +247,7 @@ openssl pkcs8 -topk8 -in privateKeys/moSubCA2.key -inform PEM -passin file:passp
 # IMPORTANT: Concatenate in such a way that the chain leads from the leaf certificate to the root (excluding), this means here: first parameter of the cat command is the sub-CA certificate which signs the leaf certificate (in this case cpoSubCA2.pem). Otherwise the Java method getCertificateChain() which is called on the keystore will only return the leaf certificate!
 cat certs/cpoSubCA2Cert.pem certs/cpoSubCA1Cert.pem > certs/intermediateCPOCACerts.pem
 # Put the seccCertificate, the private key associated with the seccCertificate as well as the intermediate sub-CA certificates in a PKCS12 container with the -certfile switch.
-openssl pkcs12 -export -inkey privateKeys/secc.key    -in certs/seccCert.pem    -name secc_cert     -certfile certs/intermediateCPOCACerts.pem -caname mo_subca_2 -caname mo_subca_1   -aes128 -passin file:passphrase.txt -passout file:passphrase.txt -out keystores/cpoCertChain.p12
+openssl pkcs12 -export -inkey privateKeys/secc.key -in certs/seccCert.pem -name secc_cert -certfile certs/intermediateCPOCACerts.pem -caname mo_subca_2 -caname mo_subca_1 -aes128 -passin file:passphrase.txt -passout file:passphrase.txt -out keystores/cpoCertChain.p12
 keytool -importkeystore -srckeystore keystores/cpoCertChain.p12 -srcstoretype pkcs12 -srcstorepass:file passphrase.txt -srcalias secc_cert -destalias secc_cert -destkeystore keystores/seccKeystore.jks -storepass:file passphrase.txt -noprompt
 #
 # 18.2) EVCC keystore needs to initally hold the OEM provisioning certificate (contract certificate will be installed with ISO 15118 message exchange)

--- a/RISE-V2G-Certificates/generateCertificates.sh
+++ b/RISE-V2G-Certificates/generateCertificates.sh
@@ -247,7 +247,7 @@ openssl pkcs8 -topk8 -in privateKeys/moSubCA2.key -inform PEM -passin file:passp
 # IMPORTANT: Concatenate in such a way that the chain leads from the leaf certificate to the root (excluding), this means here: first parameter of the cat command is the sub-CA certificate which signs the leaf certificate (in this case cpoSubCA2.pem). Otherwise the Java method getCertificateChain() which is called on the keystore will only return the leaf certificate!
 cat certs/cpoSubCA2Cert.pem certs/cpoSubCA1Cert.pem > certs/intermediateCPOCACerts.pem
 # Put the seccCertificate, the private key associated with the seccCertificate as well as the intermediate sub-CA certificates in a PKCS12 container with the -certfile switch.
-openssl pkcs12 -export -inkey privateKeys/secc.key -in certs/seccCert.pem -name secc_cert -certfile certs/intermediateCPOCACerts.pem -caname mo_subca_2 -caname mo_subca_1 -aes128 -passin file:passphrase.txt -passout file:passphrase.txt -out keystores/cpoCertChain.p12
+openssl pkcs12 -export -inkey privateKeys/secc.key    -in certs/seccCert.pem    -name secc_cert     -certfile certs/intermediateCPOCACerts.pem -caname mo_subca_2 -caname mo_subca_1   -aes128 -passin file:passphrase.txt -passout file:passphrase.txt -out keystores/cpoCertChain.p12
 keytool -importkeystore -srckeystore keystores/cpoCertChain.p12 -srcstoretype pkcs12 -srcstorepass:file passphrase.txt -srcalias secc_cert -destalias secc_cert -destkeystore keystores/seccKeystore.jks -storepass:file passphrase.txt -noprompt
 #
 # 18.2) EVCC keystore needs to initally hold the OEM provisioning certificate (contract certificate will be installed with ISO 15118 message exchange)

--- a/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/states/WaitForCertificateInstallationReq.java
+++ b/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/states/WaitForCertificateInstallationReq.java
@@ -25,6 +25,7 @@ package com.v2gclarity.risev2g.secc.states;
 
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.util.HashMap;
 
@@ -76,7 +77,7 @@ public class WaitForCertificateInstallationReq extends ServerState  {
 				ContractSignatureEncryptedPrivateKeyType encryptedContractCertPrivateKey = 
 						SecurityUtils.encryptContractCertPrivateKey(
 								(ECPublicKey) SecurityUtils.getCertificate(certificateInstallationReq.getOEMProvisioningCert()).getPublicKey(),
-								ecKeyPair,
+								(ECPrivateKey) ecKeyPair.getPrivate(),
 								getCommSessionContext().getBackendInterface().getContractCertificatePrivateKey());
 				
 				certificateInstallationRes.setContractSignatureCertChain(saContractCertificateChain);

--- a/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/states/WaitForCertificateUpdateReq.java
+++ b/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/states/WaitForCertificateUpdateReq.java
@@ -24,6 +24,7 @@
 package com.v2gclarity.risev2g.secc.states;
 
 import java.security.KeyPair;
+import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.util.HashMap;
 
@@ -72,7 +73,7 @@ public class WaitForCertificateUpdateReq extends ServerState  {
 				ContractSignatureEncryptedPrivateKeyType encryptedContractCertPrivateKey = 
 						SecurityUtils.encryptContractCertPrivateKey(
 								(ECPublicKey) SecurityUtils.getCertificate(certificateUpdateReq.getContractSignatureCertChain().getCertificate()).getPublicKey(),
-								ecdhKeyPair,
+								(ECPrivateKey) ecdhKeyPair.getPrivate(),
 								getCommSessionContext().getBackendInterface().getContractCertificatePrivateKey());
 				
 				/*

--- a/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/utils/SecurityUtils.java
+++ b/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/utils/SecurityUtils.java
@@ -1381,16 +1381,16 @@ public final class SecurityUtils {
      * @param certificateECPublicKey The public key of either the OEM provisioning certificate (in case of 
      * 								 CertificateInstallation) or the to be updated contract certificate
      * 								 (in case of CertificateUpdate)
-     * @param ecKeyPair The EC keypair
+     * @param dhPrivateKey The DH private key
      * @param contractCertPrivateKey The private key of the contract certificate
      * @return The encrypted private key of the to be installed contract certificate
      */
 	public static ContractSignatureEncryptedPrivateKeyType encryptContractCertPrivateKey(
 			ECPublicKey certificateECPublicKey, 
-			KeyPair ecKeyPair,
+			ECPrivateKey dhPrivateKey,
 			ECPrivateKey contractCertPrivateKey) {
 		// Generate the shared secret by using the public key of either OEMProvCert or ContractCert
-		byte[] sharedSecret = generateSharedSecret((ECPrivateKey) ecKeyPair.getPrivate(), certificateECPublicKey);
+		byte[] sharedSecret = generateSharedSecret(dhPrivateKey, certificateECPublicKey);
 		
 		if (sharedSecret == null) {
 			getLogger().error("Shared secret could not be generated");


### PR DESCRIPTION
Makes it easier to reuse SecurityUtils outside of the RISE-V2G project