### PR TITLE
Fixing warnings

### DIFF
--- a/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/states/ClientState.java
+++ b/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/states/ClientState.java
@@ -428,7 +428,7 @@ public abstract class ClientState extends State {
 			 * The MessageHandler method getJAXBElement() cannot be used here because of the difference in the
 			 * class name (DCEVPowerDeliveryParameter) and the name in the XSD (DC_EVPowerDeliveryParameter)
 			 */
-			JAXBElement jaxbDcEvPowerDeliveryParameter = new JAXBElement(new QName("urn:iso:15118:2:2013:MsgDataTypes", "DC_EVPowerDeliveryParameter"), 
+			JAXBElement<DCEVPowerDeliveryParameterType> jaxbDcEvPowerDeliveryParameter = new JAXBElement<>(new QName("urn:iso:15118:2:2013:MsgDataTypes", "DC_EVPowerDeliveryParameter"), 
 					DCEVPowerDeliveryParameterType.class, 
 					((IDCEVController) getCommSessionContext().getEvController()).getEVPowerDeliveryParameter());
 			powerDeliveryReq.setEVPowerDeliveryParameter(jaxbDcEvPowerDeliveryParameter);

--- a/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/evseController/DummyACEVSEController.java
+++ b/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/evseController/DummyACEVSEController.java
@@ -39,6 +39,7 @@ import com.v2gclarity.risev2g.shared.v2gMessages.msgDef.UnitSymbolType;
 
 public class DummyACEVSEController implements IACEVSEController {
 
+	@SuppressWarnings("unused")
 	private V2GCommunicationSessionSECC commSessionContext;
 	
 	public DummyACEVSEController(V2GCommunicationSessionSECC commSessionContext) {

--- a/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/evseController/DummyDCEVSEController.java
+++ b/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/evseController/DummyDCEVSEController.java
@@ -43,8 +43,11 @@ public class DummyDCEVSEController implements IDCEVSEController {
 	private V2GCommunicationSessionSECC commSessionContext;
 	private PhysicalValueType targetCurrent;
 	private PhysicalValueType targetVoltage;
+	@SuppressWarnings("unused")
 	private PhysicalValueType maximumEVVoltageLimit;
+	@SuppressWarnings("unused")
 	private PhysicalValueType maximumEVCurrentLimit;
+	@SuppressWarnings("unused")
 	private PhysicalValueType maximumEVPowerLimit;
 	private IsolationLevelType isolationLevel;
 	

--- a/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/session/V2GCommunicationSessionHandlerSECC.java
+++ b/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/session/V2GCommunicationSessionHandlerSECC.java
@@ -25,7 +25,6 @@ package com.v2gclarity.risev2g.secc.session;
 
 import java.net.DatagramPacket;
 import java.net.Inet6Address;
-import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Observable;
@@ -211,10 +210,6 @@ public class V2GCommunicationSessionHandlerSECC implements Observer {
 		return Byte.compare(getSecurity(), GlobalValues.V2G_SECURITY_WITH_TLS.getByteValue()) == 0 ? true : false;
 	}
 	
-	public void removeV2GCommunicationSession(InetAddress requesterAddress) {
-		getV2gCommunicationSessions().remove(getV2gCommunicationSessions().get(requesterAddress));
-	}
-
 	public HashMap<String, V2GCommunicationSessionSECC> getV2gCommunicationSessions() {
 		return v2gCommunicationSessions;
 	}

--- a/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/session/V2GCommunicationSessionSECC.java
+++ b/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/session/V2GCommunicationSessionSECC.java
@@ -89,7 +89,6 @@ public class V2GCommunicationSessionSECC extends V2GCommunicationSession impleme
 	private short chosenSAScheduleTuple;
 	private IACEVSEController acEvseController;
 	private IDCEVSEController dcEvseController;
-	private IEVSEController evseController;
 	private IBackendInterface backendInterface;
 	private boolean oldSessionJoined;
 	private byte[] incomingV2GTPMessage;
@@ -457,11 +456,6 @@ public class V2GCommunicationSessionSECC extends V2GCommunicationSession impleme
 				return null;
 			}
 		} else return acEvseController; // just AC controller as default
-	}
-
-
-	public void setEvseController(IEVSEController evseController) {
-		this.evseController = evseController;
 	}
 
 

--- a/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/states/WaitForMeteringReceiptReq.java
+++ b/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/states/WaitForMeteringReceiptReq.java
@@ -147,7 +147,7 @@ public class WaitForMeteringReceiptReq extends ServerState {
 			 * The MessageHandler method getJAXBElement() cannot be used here because of the difference in the
 			 * class name (ACEVSEStatus) and the name in the XSD (AC_EVSEStatus)
 			 */
-			JAXBElement jaxbEVSEStatus = new JAXBElement(new QName("urn:iso:15118:2:2013:MsgDataTypes", "AC_EVSEStatus"), 
+			JAXBElement<ACEVSEStatusType> jaxbEVSEStatus = new JAXBElement<>(new QName("urn:iso:15118:2:2013:MsgDataTypes", "AC_EVSEStatus"), 
 					ACEVSEStatusType.class, 
 					getCommSessionContext().getACEvseController().getACEVSEStatus(EVSENotificationType.NONE));
 			meteringReceiptRes.setEVSEStatus(jaxbEVSEStatus);
@@ -156,7 +156,7 @@ public class WaitForMeteringReceiptReq extends ServerState {
 			 * The MessageHandler method getJAXBElement() cannot be used here because of the difference in the
 			 * class name (DCEVSEStatus) and the name in the XSD (DC_EVSEStatus)
 			 */
-			JAXBElement jaxbACEVSEStatus = new JAXBElement(new QName("urn:iso:15118:2:2013:MsgDataTypes", "DC_EVSEStatus"), 
+			JAXBElement<DCEVSEStatusType> jaxbACEVSEStatus = new JAXBElement<>(new QName("urn:iso:15118:2:2013:MsgDataTypes", "DC_EVSEStatus"), 
 					DCEVSEStatusType.class, 
 					getCommSessionContext().getDCEvseController().getDCEVSEStatus(EVSENotificationType.NONE));
 			meteringReceiptRes.setEVSEStatus(jaxbACEVSEStatus);

--- a/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/states/WaitForPowerDeliveryReq.java
+++ b/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/states/WaitForPowerDeliveryReq.java
@@ -180,7 +180,7 @@ public class WaitForPowerDeliveryReq extends ServerState {
 			 * The MiscUtils method getJAXBElement() cannot be used here because of the difference in the
 			 * class name (ACEVSEStatus) and the name in the XSD (AC_EVSEStatus)
 			 */
-			JAXBElement jaxbEVSEStatus = new JAXBElement(new QName("urn:iso:15118:2:2013:MsgDataTypes", "AC_EVSEStatus"), 
+			JAXBElement<ACEVSEStatusType> jaxbEVSEStatus = new JAXBElement<>(new QName("urn:iso:15118:2:2013:MsgDataTypes", "AC_EVSEStatus"), 
 					ACEVSEStatusType.class, 
 					getCommSessionContext().getACEvseController().getACEVSEStatus(EVSENotificationType.NONE));
 			powerDeliveryRes.setEVSEStatus(jaxbEVSEStatus);
@@ -189,7 +189,7 @@ public class WaitForPowerDeliveryReq extends ServerState {
 			 * The MiscUtils method getJAXBElement() cannot be used here because of the difference in the
 			 * class name (DCEVSEStatus) and the name in the XSD (DC_EVSEStatus)
 			 */
-			JAXBElement jaxbACEVSEStatus = new JAXBElement(new QName("urn:iso:15118:2:2013:MsgDataTypes", "DC_EVSEStatus"), 
+			JAXBElement<DCEVSEStatusType> jaxbACEVSEStatus = new JAXBElement<>(new QName("urn:iso:15118:2:2013:MsgDataTypes", "DC_EVSEStatus"), 
 					DCEVSEStatusType.class, 
 					getCommSessionContext().getDCEvseController().getDCEVSEStatus(EVSENotificationType.NONE));
 			powerDeliveryRes.setEVSEStatus(jaxbACEVSEStatus);

--- a/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/exiCodec/EXIficientCodec.java
+++ b/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/exiCodec/EXIficientCodec.java
@@ -222,6 +222,7 @@ public final class EXIficientCodec extends ExiCodec {
 		this.exiFactory = exiFactory;
 	}
 
+	@SuppressWarnings("unused")
 	private GrammarFactory getGrammarFactory() {
 		return grammarFactory;
 	}

--- a/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/exiCodec/ExiCodec.java
+++ b/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/exiCodec/ExiCodec.java
@@ -42,6 +42,7 @@ import com.v2gclarity.risev2g.shared.utils.ByteUtils;
 import com.v2gclarity.risev2g.shared.utils.MiscUtils;
 import com.v2gclarity.risev2g.shared.v2gMessages.appProtocol.SupportedAppProtocolReq;
 import com.v2gclarity.risev2g.shared.v2gMessages.appProtocol.SupportedAppProtocolRes;
+import com.v2gclarity.risev2g.shared.v2gMessages.msgDef.SignedInfoType;
 import com.v2gclarity.risev2g.shared.v2gMessages.msgDef.V2GMessage;
 
 public abstract class ExiCodec {
@@ -164,7 +165,7 @@ public abstract class ExiCodec {
 	 * @param jaxbSignedInfo The SignedInfo element of the V2GMessage header, given as a JAXB element
 	 * @return The EXI encoding of the SignedInfo element given as a byte array
 	 */
-	public byte[] getExiEncodedSignedInfo(JAXBElement jaxbSignedInfo) {
+	public byte[] getExiEncodedSignedInfo(JAXBElement<SignedInfoType> jaxbSignedInfo) {
 		// The schema-informed fragment grammar option needs to be used for EXI encodings in the header's signature
 		setFragment(true);
 		

--- a/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/exiCodec/OpenEXICodec.java
+++ b/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/exiCodec/OpenEXICodec.java
@@ -246,6 +246,7 @@ public final class OpenEXICodec extends ExiCodec {
 		this.exiSchemaFactory = exiSchemaFactory;
 	}
 
+	@SuppressWarnings("unused")
 	private InputStream getSchemaMsgDefIS() {
 		return schemaMsgDefIS;
 	}

--- a/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/messageHandling/MessageHandler.java
+++ b/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/messageHandling/MessageHandler.java
@@ -229,18 +229,17 @@ public final class MessageHandler {
 	 * message. In case of XML signature generation, for some messages certain fields need to be signed
 	 * instead of the complete message. 
 	 * 
-	 * Suppressed unchecked warning, previously used a type-safe version such as new 
-	 * JAXBElement<SessionStopReqType>(new QName ... ) but this seems to work as well 
-	 * (I don't know how to infer the type correctly)
+	 * Suppressed unchecked warning, because the cast is inferred from the type
+	 * of messageOrField parameter 
 	 * 
 	 * @param messageOrField The message or field for which a digest is to be generated
 	 * @return The JAXBElement of the provided message or field
 	 */
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public synchronized JAXBElement getJaxbElement(Object messageOrField) {
+	@SuppressWarnings({ "unchecked" })
+	public synchronized <T> JAXBElement<T> getJaxbElement(T messageOrField) {
 		String messageName = messageOrField.getClass().getSimpleName().replace("Type", "");
 		String namespace = "";
-		JAXBElement jaxbElement = null;
+		JAXBElement<T> jaxbElement = null;
 		
 		if (messageOrField instanceof SignedInfoType) {
 			namespace = GlobalValues.V2G_CI_XMLDSIG_NAMESPACE.toString();
@@ -273,8 +272,8 @@ public final class MessageHandler {
 			}
 		}
 		
-		jaxbElement = new JAXBElement(new QName(namespace, messageName), 
-				messageOrField.getClass(), 
+		jaxbElement = new JAXBElement<T>(new QName(namespace, messageName), 
+				(Class<T>) messageOrField.getClass(), 
 				messageOrField);
 		
 		return jaxbElement; 

--- a/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/messageHandling/MessageHandler.java
+++ b/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/messageHandling/MessageHandler.java
@@ -301,7 +301,7 @@ public final class MessageHandler {
 		this.jaxbContext = jaxbContext;
 	}
 	
-	public synchronized void setJaxbContext(Class... classesToBeBound) {
+	public synchronized void setJaxbContext(@SuppressWarnings("rawtypes") Class... classesToBeBound) {
 		try {
 			setJaxbContext(JAXBContext.newInstance(classesToBeBound));
 			

--- a/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/misc/State.java
+++ b/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/misc/State.java
@@ -93,7 +93,6 @@ public abstract class State {
 			int timeout) {
 		String messageName = message.getClass().getSimpleName().replace("Type", "");
 		
-		@SuppressWarnings({"unchecked"})
 		V2GMessage v2gMessage = getMessageHandler().getV2GMessage(
 				getCommSessionContext().getSessionID(),
 				getXMLSignatureRefElements(), 

--- a/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/utils/MiscUtils.java
+++ b/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/utils/MiscUtils.java
@@ -26,7 +26,6 @@ package com.v2gclarity.risev2g.shared.utils;
 			import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;

--- a/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/utils/SecurityUtils.java
+++ b/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/utils/SecurityUtils.java
@@ -1819,7 +1819,7 @@ public final class SecurityUtils {
 	 */
 	public static boolean verifySignature(
 			SignatureType signature, 
-			JAXBElement jaxbSignature,
+			JAXBElement<SignedInfoType> jaxbSignature,
 			HashMap<String, byte[]> verifyXMLSigRefElements, 
 			byte[] verifyCert) {
 		X509Certificate x509VerifyCert = getCertificate(verifyCert);
@@ -1840,7 +1840,7 @@ public final class SecurityUtils {
 	 */
 	public static boolean verifySignature(
 				SignatureType signature,
-				JAXBElement jaxbSignedInfo,
+				JAXBElement<SignedInfoType> jaxbSignedInfo,
 				HashMap<String, byte[]> verifyXMLSigRefElements, 
 				X509Certificate verifyCert) {
 		byte[] calculatedReferenceDigest; 
@@ -1937,7 +1937,7 @@ public final class SecurityUtils {
 	private static void showSignatureVerificationLog(
 			X509Certificate verifyCert, 
 			SignatureType signature, 
-			JAXBElement jaxbSignedInfo, 
+			JAXBElement<SignedInfoType> jaxbSignedInfo, 
 			ECPublicKey ecPublicKey) {
 		byte[] computedSignedInfoDigest = generateDigest("", jaxbSignedInfo);
 		byte[] receivedSignatureValue = signature.getSignatureValue().getValue();


### PR DESCRIPTION
Dear Marc,

I've managed to reduce the number of warnings from fourty-something to 9. I've organized my changes in commits according to the change type to make it easier to review.

I've used the following principles:
 - I've fixed the warning wherever it seemed to be easy to fix
 - I've suppressed the warnings where it didn't seemed to be likely that the code would change in any ways, or the unused field or method served architectural goals
 - however I did not suppress the warnings where the code contained a todo, or the field served as an example. In these cases I believe the warning can be an indication that those parts will need more attention

Feel free to add any comments or requests, I'll update my pull request according to those.
