### PR TITLE
Fix typo that results in a null pointer when ChargingStatusRes hasn't populate the ReceiptRequired field

### DIFF
--- a/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/states/WaitForChargingStatusRes.java
+++ b/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/states/WaitForChargingStatusRes.java
@@ -56,7 +56,7 @@ public class WaitForChargingStatusRes extends ClientState {
 			 * a MeteringReceiptRequest. If no TLS is used, a MeteringReceiptRequest may not be sent because
 			 * a signature cannot be applied without private key of the contract certificate.
 			 */
-			if (chargingStatusRes.isReceiptRequired() != null & chargingStatusRes.isReceiptRequired() && getCommSessionContext().isTlsConnection()) {
+			if (chargingStatusRes.isReceiptRequired() != null && chargingStatusRes.isReceiptRequired() && getCommSessionContext().isTlsConnection()) {
 				MeteringReceiptReqType meteringReceiptReq = new MeteringReceiptReqType();
 				/*
 				 * Experience from the test symposium in San Diego (April 2016):


### PR DESCRIPTION
The old implementation uses a bitwise comparison 
that will validate both statements and will result
in a null pointer. The fix will do a
 logic comparison that will return if the first 
statement is null

See also cc26d2a23955a2b4e0910cc265ef5fe1fbac5e6c