### PR TITLE
Fix NoSuchMethodError: java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuff…

### DIFF
--- a/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/misc/V2GTPMessage.java
+++ b/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/misc/V2GTPMessage.java
@@ -23,6 +23,7 @@
  *******************************************************************************/
 package com.v2gclarity.risev2g.shared.misc;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
@@ -154,7 +155,7 @@ public class V2GTPMessage {
 		
 		// Sets the messageBuffers's position in order for the .get() message to work without 
 		// throwing a BufferUnderflowException
-		messageBuffer.position(0);
+		((Buffer)messageBuffer).position(0);
 		
 		messageBuffer.get(this.message);
 

--- a/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/utils/ByteUtils.java
+++ b/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/utils/ByteUtils.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.BufferOverflowException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import javax.xml.bind.DatatypeConverter;
@@ -174,11 +175,11 @@ public final class ByteUtils {
 		 * Response only holds 2 bytes. Thus, we must account for this and guarantee the Big Endian 
 		 * byte order.
 		 */
-		bb.position(4 - byteArray.length);
+		((Buffer)bb).position(4 - byteArray.length);
 		bb.put(byteArray);
 		
 		// Setting the current position to 0, otherwise getInt() would throw a BufferUnderflowException
-		bb.position(0);
+		((Buffer)bb).position(0);
 		
 		return bb.getInt();
 	}
@@ -195,7 +196,7 @@ public final class ByteUtils {
 			
 		// In case the provided byte array is smaller than 8 bytes (e.g. int has 4 bytes), take care that they are placed at the right-most position
 		if (byteArray.length < 8) {
-			bb.position(8-byteArray.length);
+			((Buffer)bb).position(8-byteArray.length);
 			bb.put(byteArray);
 		} else {
 			try {
@@ -204,13 +205,13 @@ public final class ByteUtils {
 				getLogger().warn("Byte array length is too big (" + byteArray.length + " bytes) to be converted " +
 								 "into a long value. Only the right-most 8 bytes (least significant bytes " +
 								 "according to Big Endian) are used.", e);
-				bb.position(0);
+				((Buffer)bb).position(0);
 				bb.put(byteArray, byteArray.length - 8, byteArray.length);
 			}
 		}
 		
 		// Setting the current position to 0, otherwise getLong() would throw a BufferUnderflowException
-		bb.position(0);
+		((Buffer)bb).position(0);
 		
 		return bb.getLong();
 	}

--- a/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/v2gMessages/SECCDiscoveryRes.java
+++ b/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/v2gMessages/SECCDiscoveryRes.java
@@ -23,6 +23,7 @@
  *******************************************************************************/
 package com.v2gclarity.risev2g.shared.v2gMessages;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
@@ -94,7 +95,7 @@ public class SECCDiscoveryRes {
 		
 		// Sets the messageBuffers's position in order for the .get() message to work without 
 		// throwing a BufferUnderflowException
-		payloadBuffer.position(0);
+		((Buffer)payloadBuffer).position(0);
 		
 		payloadBuffer.get(payload);
 		


### PR DESCRIPTION
At ElaadNL we are currently working with the RiseV2G application. During the development process we encountered difficulties when compiling for release 8. This should also be possible with JDK9 because there is backward compatibility. The following happens:

The call byteBuffer.position(0) in JDK 8 calls method Buffer.position(I)LBuffer while in JDK 9+ calls method ByteBuffer.position(I)LByteBuffer.
When a JVM 8 sees the latter it does not find it, hence the error.

This seems to be a problem in javac but it is fixed easily this way.

I know this is not a very important fix for the overall functionality but it makes RiseV2G easier to compile in different setups.