### PR TITLE
Remove singleton instances once the client is finished

### DIFF
--- a/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/transportLayer/TCPClient.java
+++ b/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/transportLayer/TCPClient.java
@@ -139,7 +139,7 @@ public class TCPClient extends StatefulTransportLayerClient {
 				getInStream().close();
 				getOutStream().close();
 				getTcpSocketToServer().close();
-				releaseInstance();
+				uniqueTCPClientInstance = null;
 				Thread.currentThread().interrupt();
 			} catch (IOException e) {
 				getLogger().error("Error occurred while trying to close TCP socket to server", e);
@@ -147,10 +147,6 @@ public class TCPClient extends StatefulTransportLayerClient {
 			
 			getLogger().debug("TCP client stopped");
 		}
-	}
-	
-	private static void releaseInstance() {
-		uniqueTCPClientInstance = null;
 	}
 	
 	public Socket getTcpSocketToServer() {

--- a/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/transportLayer/TCPClient.java
+++ b/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/transportLayer/TCPClient.java
@@ -139,6 +139,7 @@ public class TCPClient extends StatefulTransportLayerClient {
 				getInStream().close();
 				getOutStream().close();
 				getTcpSocketToServer().close();
+				releaseInstance();
 				Thread.currentThread().interrupt();
 			} catch (IOException e) {
 				getLogger().error("Error occurred while trying to close TCP socket to server", e);
@@ -146,6 +147,10 @@ public class TCPClient extends StatefulTransportLayerClient {
 			
 			getLogger().debug("TCP client stopped");
 		}
+	}
+	
+	private static void releaseInstance() {
+		uniqueTCPClientInstance = null;
 	}
 	
 	public Socket getTcpSocketToServer() {

--- a/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/transportLayer/TLSClient.java
+++ b/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/transportLayer/TLSClient.java
@@ -211,7 +211,7 @@ public class TLSClient extends StatefulTransportLayerClient {
 				getInStream().close();
 				getOutStream().close();
 				getTlsSocketToServer().close();
-				releaseInstance();
+				uniqueTLSClientInstance = null;
 				Thread.currentThread().interrupt();
 			} catch (IOException e) {
 				getLogger().error("Error occurred while trying to close TCP socket to server", e);
@@ -219,10 +219,6 @@ public class TLSClient extends StatefulTransportLayerClient {
 			
 			getLogger().debug("TLS client stopped");
 		}
-	}
-	
-	private static void releaseInstance() {
-		uniqueTLSClientInstance = null;
 	}
 	
 	

--- a/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/transportLayer/TLSClient.java
+++ b/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/transportLayer/TLSClient.java
@@ -211,6 +211,7 @@ public class TLSClient extends StatefulTransportLayerClient {
 				getInStream().close();
 				getOutStream().close();
 				getTlsSocketToServer().close();
+				releaseInstance();
 				Thread.currentThread().interrupt();
 			} catch (IOException e) {
 				getLogger().error("Error occurred while trying to close TCP socket to server", e);
@@ -218,6 +219,10 @@ public class TLSClient extends StatefulTransportLayerClient {
 			
 			getLogger().debug("TLS client stopped");
 		}
+	}
+	
+	private static void releaseInstance() {
+		uniqueTLSClientInstance = null;
 	}
 	
 	

--- a/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/transportLayer/UDPClient.java
+++ b/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/transportLayer/UDPClient.java
@@ -51,7 +51,7 @@ public class UDPClient {
 	 *  access the instance variable -> thread safe.
 	 */
 	private Logger logger = LogManager.getLogger(this.getClass().getSimpleName());
-	private static final UDPClient uniqueUDPClientInstance = new UDPClient();
+	private static UDPClient uniqueUDPClientInstance = new UDPClient();
 	private int multicastSocketPort;
 	private Inet6Address multicastAddress;
 	private MulticastSocket socketToUDPServer;
@@ -106,6 +106,13 @@ public class UDPClient {
 	
 
 	public static UDPClient getInstance() {
+		if (uniqueUDPClientInstance == null) {
+			synchronized (UDPClient.class) {
+				if (uniqueUDPClientInstance == null) {
+					uniqueUDPClientInstance = new UDPClient();
+				}
+			}
+		}
 		return uniqueUDPClientInstance;
 	}
 	
@@ -144,6 +151,11 @@ public class UDPClient {
 	public void stop() {
 		getSocketToUDPServer().close();
 		getLogger().debug("UDP client stopped");
+		releaseInstance();
+	}
+	
+	private static void releaseInstance() {
+		uniqueUDPClientInstance = null;
 	}
 	
 	

--- a/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/transportLayer/UDPClient.java
+++ b/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/transportLayer/UDPClient.java
@@ -105,13 +105,9 @@ public class UDPClient {
 	}
 	
 
-	public static UDPClient getInstance() {
+	public static synchronized UDPClient getInstance() {
 		if (uniqueUDPClientInstance == null) {
-			synchronized (UDPClient.class) {
-				if (uniqueUDPClientInstance == null) {
-					uniqueUDPClientInstance = new UDPClient();
-				}
-			}
+			uniqueUDPClientInstance = new UDPClient();
 		}
 		return uniqueUDPClientInstance;
 	}
@@ -151,10 +147,6 @@ public class UDPClient {
 	public void stop() {
 		getSocketToUDPServer().close();
 		getLogger().debug("UDP client stopped");
-		releaseInstance();
-	}
-	
-	private static void releaseInstance() {
 		uniqueUDPClientInstance = null;
 	}
 	


### PR DESCRIPTION
I have tried to run the client session multiple times from the same application, but several unexpected behavior occurred. For example the TCP client was reading stale data even though I made sure I have created a fresh V2GCommunicationSessionHandlerEVCC and TCPClient instances.

I was trying to track down wich buffer was not reinitialized, but then I realized it's easier to drop the client instances completely once they are stopped.

This PR fixed the problems for me.