### PR TITLE
Use try with resources when handling FileStreams

### DIFF
--- a/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/utils/SecurityUtils.java
+++ b/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/utils/SecurityUtils.java
@@ -1008,9 +1008,9 @@ public final class SecurityUtils {
 						getCertificateChain(contractCertChain)); 
 				
 				// Save the keystore persistently
-				FileOutputStream fos = new FileOutputStream("evccKeystore.jks");
-				keyStore.store(fos, GlobalValues.PASSPHRASE_FOR_CERTIFICATES_AND_KEYS.toString().toCharArray());
-				fos.close();
+				try(FileOutputStream fos = new FileOutputStream("evccKeystore.jks")){
+					keyStore.store(fos, GlobalValues.PASSPHRASE_FOR_CERTIFICATES_AND_KEYS.toString().toCharArray());
+				}
 				
 				X509Certificate contractCert = getCertificate(contractCertChain.getCertificate());
 				


### PR DESCRIPTION
try-with-resources statement, guarantees that the resource will be closed