### PR TITLE
Treat DC Shutdown status as valid when STOP power delivery is requested

### DIFF
--- a/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/states/WaitForPowerDeliveryReq.java
+++ b/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/states/WaitForPowerDeliveryReq.java
@@ -152,8 +152,11 @@ public class WaitForPowerDeliveryReq extends ServerState {
 				dcEVSEStatusCode.equals(DCEVSEStatusCodeType.EVSE_EMERGENCY_SHUTDOWN) || 
 				dcEVSEStatusCode.equals(DCEVSEStatusCodeType.EVSE_MALFUNCTION)) {
 				getLogger().error("EVSE status code is '" + dcEVSEStatusCode.toString() + "'");
-				powerDeliveryRes.setResponseCode(ResponseCodeType.FAILED_POWER_DELIVERY_NOT_APPLIED);
-				return false;
+				
+				if (!powerDeliveryReq.getChargeProgress().equals(ChargeProgressType.STOP)) {
+					powerDeliveryRes.setResponseCode(ResponseCodeType.FAILED_POWER_DELIVERY_NOT_APPLIED);
+					return false;
+				}
 			}
 					
 		}

--- a/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/states/WaitForPowerDeliveryReq.java
+++ b/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/states/WaitForPowerDeliveryReq.java
@@ -151,7 +151,7 @@ public class WaitForPowerDeliveryReq extends ServerState {
 				dcEVSEStatusCode.equals(DCEVSEStatusCodeType.EVSE_SHUTDOWN) ||
 				dcEVSEStatusCode.equals(DCEVSEStatusCodeType.EVSE_EMERGENCY_SHUTDOWN) || 
 				dcEVSEStatusCode.equals(DCEVSEStatusCodeType.EVSE_MALFUNCTION)) {
-				getLogger().error("EVSE status code is '" + dcEVSEStatusCode.toString() + "'");
+				getLogger().warn("EVSE status code is '" + dcEVSEStatusCode.toString() + "'");
 				
 				if (!powerDeliveryReq.getChargeProgress().equals(ChargeProgressType.STOP)) {
 					powerDeliveryRes.setResponseCode(ResponseCodeType.FAILED_POWER_DELIVERY_NOT_APPLIED);


### PR DESCRIPTION
When an EVSE side shutdown is initated it's hard to tell from the controller point of view wich exact state is requested. So in WaitForPowerDeliveryReq we treat EVSE_SHUTDOWN and similar status codes as valid when the EV requested a stop.

Without this a FAILED_PowerDeliveryNotApplied will be responded wich is not expected at the EV side.