### PR TITLE
Fix typo, verify leaf certificate attributes

### DIFF
--- a/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/utils/SecurityUtils.java
+++ b/RISE-V2G-Shared/src/main/java/com/v2gclarity/risev2g/shared/utils/SecurityUtils.java
@@ -434,8 +434,7 @@ public final class SecurityUtils {
 		
 		
 		responseCode = verifyLeafCertificateAttributes(leafCertificate, pki);
-		if (responseCode.equals(ResponseCodeType.OK))
-			return responseCode;
+		if (!responseCode.equals(ResponseCodeType.OK)) return responseCode;
 		
 		return ResponseCodeType.OK;
 	}


### PR DESCRIPTION
The result of the verify leaf certificate attributes was ignored and always be OK. This fix will return corresponding error when verify leaf certificate attributes returns a not OK response code.