### PR TITLE
Don't set timeout for receiving a message before sending the first one.

### DIFF
--- a/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/transportLayer/StatefulTransportLayerClient.java
+++ b/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/transportLayer/StatefulTransportLayerClient.java
@@ -60,7 +60,7 @@ public abstract class StatefulTransportLayerClient  extends Observable implement
 		setClientPort(MiscUtils.getRandomPortNumber());
 		setClientAddress(MiscUtils.getLinkLocalAddress());
 		setV2gTPHeader(new byte[8]);
-		setTimeout(TimeRestrictions.getV2gEvccMsgTimeout(V2GMessages.SUPPORTED_APP_PROTOCOL_RES)); // Needed for the supportedAppProtocol timeout
+		setTimeout(-1); 
 	}
 	
 	protected boolean processIncomingMessage() throws IOException {


### PR DESCRIPTION
`if (!startTransportLayerClient(seccDiscoveryRes, seccAddress)) return false;
                        
setV2gCommunicationSessionEVCC(new V2GCommunicationSessionEVCC(getTransportLayerClient()));

/*
 * Tell the TCP- or TLSClient to notify if 
 * - a new V2GTPMessage has arrived
 * - a timeout has occurred while waiting for the respective response message
 */
getTransportLayerClient().addObserver(getV2gCommunicationSessionEVCC());

getV2gCommunicationSessionEVCC().addObserver(this);

// Set TLS security flag for communication session
boolean secureConn = (((Byte) getSecurity()).compareTo((Byte) GlobalValues.V2G_SECURITY_WITH_TLS.getByteValue()) == 0) ? true : false;
getV2gCommunicationSessionEVCC().setTlsConnection(secureConn);

sendSupportedAppProtocolReq();`

The timeout for receiving a message in TCPClient/TCPClient can expire before SupportedAppProtocolReq is sent if the creation of an evController takes too long (in new V2GCommunicationSessionEVCC).