### PR TITLE
Mitigates CVE-2021-45046

### DIFF
--- a/RISE-V2G-Shared/pom.xml
+++ b/RISE-V2G-Shared/pom.xml
@@ -37,12 +37,12 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-api</artifactId>
-		    <version>2.13.3</version>
+		    <version>[2.16.0,)</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-core</artifactId>
-		    <version>2.13.3</version>
+		    <version>[2.16.0,)</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sourceforge.openexi</groupId>


### PR DESCRIPTION
Need to update the dependency version, or to filter by using 'formatMsgNoLookups'.

This vulnerability isn't strickly easy to exploit, but an EVCC can send this encoded payload to the EVSE, and trigger the bug during even in the first `supportedAppProtocolReq` state:
```
80027123DB53732349D363230B81D1797BC123DB437B9BA2730B6B2BE97261A2517199B33BC98B0B9B6B09B311BB119B198BBBD3B3CB33B9B38BA9731B0B730B93CBA37B5B2B7399731B7B697B0BE8020000280040
```