### PR TITLE
  fix RISE ServiceDetail parameter according to standard

### DIFF
--- a/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/states/WaitForServiceDetailReq.java
+++ b/RISE-V2G-SECC/src/main/java/com/v2gclarity/risev2g/secc/states/WaitForServiceDetailReq.java
@@ -140,12 +140,15 @@ public class WaitForServiceDetailReq extends ServerState {
 	private ParameterSetType getInternetAccessFTPPort20Parameters() {	
 		ParameterSetType parameterSet = new ParameterSetType();
 		
-		ParameterType ftpPort20 = new ParameterType();
-		ftpPort20.setName("FTP20");
-		ftpPort20.setStringValue("ftp");
-		ftpPort20.setIntValue(20);
-		
-		parameterSet.getParameter().add(ftpPort20);
+		ParameterType ftpPort20_str = new ParameterType();
+		ParameterType ftpPort20_int = new ParameterType();
+		ftpPort20_str.setName("Protocol");
+		ftpPort20_str.setStringValue("ftp");
+		ftpPort20_int.setName("Port");
+		ftpPort20_int.setIntValue(20);
+
+		parameterSet.getParameter().add(ftpPort20_str);
+		parameterSet.getParameter().add(ftpPort20_int);
 		parameterSet.setParameterSetID((short) 1);
 		
 		return parameterSet;
@@ -155,12 +158,15 @@ public class WaitForServiceDetailReq extends ServerState {
 	private ParameterSetType getInternetAccessFTPPort21Parameters() {	
 		ParameterSetType parameterSet = new ParameterSetType();
 		
-		ParameterType ftpPort21 = new ParameterType();
-		ftpPort21.setName("FTP21");
-		ftpPort21.setStringValue("ftp");
-		ftpPort21.setIntValue(21);
-		
-		parameterSet.getParameter().add(ftpPort21);
+		ParameterType ftpPort21_str = new ParameterType();
+		ParameterType ftpPort21_int = new ParameterType();
+		ftpPort21_str.setName("Protocol");
+		ftpPort21_str.setStringValue("ftp");
+		ftpPort21_int.setName("Port");
+		ftpPort21_int.setIntValue(21);
+
+		parameterSet.getParameter().add(ftpPort21_str);
+		parameterSet.getParameter().add(ftpPort21_int);
 		parameterSet.setParameterSetID((short) 2);
 		
 		return parameterSet;
@@ -170,12 +176,15 @@ public class WaitForServiceDetailReq extends ServerState {
 	private ParameterSetType getInternetAccessHTTPParameters() {	
 		ParameterSetType parameterSet = new ParameterSetType();
 		
-		ParameterType http = new ParameterType();
-		http.setName("HTTP port 80");
-		http.setStringValue("http");
-		http.setIntValue(80);
-		
-		parameterSet.getParameter().add(http);
+		ParameterType http_int = new ParameterType();
+		ParameterType http_str = new ParameterType();
+		http_str.setName("Protocol");
+		http_str.setStringValue("https");
+		http_int.setName("Port");
+		http_int.setIntValue(80);
+
+		parameterSet.getParameter().add(http_str);
+		parameterSet.getParameter().add(http_int);
 		parameterSet.setParameterSetID((short) 3);
 		
 		return parameterSet;
@@ -185,12 +194,15 @@ public class WaitForServiceDetailReq extends ServerState {
 	private ParameterSetType getInternetAccessHTTPSParameters() {	
 		ParameterSetType parameterSet = new ParameterSetType();
 		
-		ParameterType https = new ParameterType();
-		https.setName("HTTP port 443");
-		https.setStringValue("https");
-		https.setIntValue(443);
-		
-		parameterSet.getParameter().add(https);
+		ParameterType https_int = new ParameterType();
+		ParameterType https_str = new ParameterType();
+		https_str.setName("Protocol");
+		https_str.setStringValue("https");
+		https_int.setName("Port");
+		https_int.setIntValue(443);
+
+		parameterSet.getParameter().add(https_str);
+		parameterSet.getParameter().add(https_int);
 		parameterSet.setParameterSetID((short) 4);
 		
 		return parameterSet;


### PR DESCRIPTION
## DESCRIPTION

During test of communication with vehicule that require VAS (value added services) it needs Internet connection to access remote services.

We noticed the ServiceDetailsRes EXI packet is not correct, and do not match the standard ISO15118 description.

V2G2-348 The massage element shall be used as defined in table 85

Especialy the sentence in table 85:  Only one for each parameter can be selected,


Moreover the V2G message exemple 8 ServiceDetailsRes message (page 279) in standard 15118-2:2014(E)
shows clearly the multiple occurence of parameter fields for each protocol and port which justify the current fix.

```XML
<v2gci_t:ParameterSet>
    <v2gci_t:ParameterSetID>3</v2gci_t:ParameterSetID>
    <v2gci_t:Parameter v2gci_t:Name="Protocol">
        <v2gci_t:stringValue>HTTP</v2gci_t:stringValue>
    </v2gci_t:Parameter>
    <v2gci_t:Parameter v2gci_t:Name="Port">
        <v2gci_t:intValue>80</v2gci_t:intValue>
    </v2gci_t:Parameter>
</v2gci_t:ParameterSet>
<v2gci_t:ParameterSet>
    <v2gci_t:ParameterSetID>4</v2gci_t:ParameterSetID>
    <v2gci_t:Parameter v2gci_t:Name="Protocol">
        <v2gci_t:stringValue>HTTPS</v2gci_t:stringValue>
    </v2gci_t:Parameter>
    <v2gci_t:Parameter v2gci_t:Name="Port">
        <v2gci_t:intValue>443</v2gci_t:intValue>
    </v2gci_t:Parameter>
</v2gci_t:ParameterSet>
```

Although RISE is no more supported, please find this pull request as participation to the community and help to make EV charger more compatible with standard.